### PR TITLE
Fixed service loading

### DIFF
--- a/shizapret.bat
+++ b/shizapret.bat
@@ -11,7 +11,7 @@ cd /d "%~dp0"
 
 call service.bat status_zapret
 
-if not exist "bin/winws.exe" (
+if not exist "bin/cygwin1.dll" (
     call update.bat bin
 )
 


### PR DESCRIPTION
Changed checking of "bin/winws.exe" to "bin/cygwin1.dll" because token "bin/winws.exe" is used by "service.bat" to parse the arguments to start the service.